### PR TITLE
Disable Markdownlint rule MD034

### DIFF
--- a/.mdl_style.rb
+++ b/.mdl_style.rb
@@ -3,5 +3,6 @@ all
 exclude_rule 'MD013'
 rule 'MD029', style: ['ordered']
 exclude_rule 'MD033'
+exclude_rule 'MD034'
 exclude_rule 'MD041'
 exclude_rule 'MD047'


### PR DESCRIPTION
Disable Markdownlint rule MD034 to avoid fighting with the raw HTML links terraform-docs puts into our README.md every time it runs.