### PR TITLE
ci: fix pre-commit pipeline

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Install Python3
         uses: actions/setup-python@v5
+        with:
+          python-version: 3
 
       - name: Install tflint
         uses: terraform-linters/setup-tflint@v4


### PR DESCRIPTION
Fix our pre-commit CI workflow to function with current ubuntu-latest image by specifying a python version to the setup-python action.