### PR TITLE
feat: validate user's password hash

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -108,7 +108,12 @@ variable "esxi_ntp_server" {
 }
 variable "esxi_password" {
   type        = string
+  sensitive   = true
   description = "mkpasswd Pre-hashed root password to be set for ESXi instances (Hash the password from vcf-ems-deployment-parameter.xlsx > Credentials Sheet > C8 using 'mkpasswd --method=SHA-512' from Linux whois package)"
+  validation {
+    condition     = length(var.esxi_password) > 98 && substr(var.esxi_password, 0, 3) == "$6$"
+    error_message = "The esxi_password value must be a valid SHA 512 password hash, starting with \"$6$\". Use 'mkpasswd --method=SHA-512' from the whois package to generate a valid hash."
+  }
 }
 variable "esxi_plan" {
   type        = string


### PR DESCRIPTION
This PR puts some basic validation checks on the esxi_password field to avoid a common error folks are running into where they forget to supply a password hash or supply the wrong format.